### PR TITLE
fix: setOutput call

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -10423,7 +10423,7 @@ async function run() {
 
     const id = await generateReleaseNotes(octokit, github.context.repo)
 
-    core.setOutput(id)
+    core.setOutput('releaseId', id)
   } catch (err) {
     core.setFailed(err.message)
   }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -10,7 +10,7 @@ async function run() {
 
     const id = await generateReleaseNotes(octokit, github.context.repo)
 
-    core.setOutput(id)
+    core.setOutput('releaseId', id)
   } catch (err) {
     core.setFailed(err.message)
   }


### PR DESCRIPTION
## Summary

`.setOutput` accepts a name and value; we were calling this function incorrectly. Output is unused ATM, so we never noticed.